### PR TITLE
feat(seno): add base64_decode

### DIFF
--- a/decode64
+++ b/decode64
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+require "base64";
+if ARGV[0] != nil then
+        puts Base64.urlsafe_decode64(ARGV[0]);
+end
+


### PR DESCRIPTION
# what

- base64でエンコードされた文字列をデコードするスクリプトを追加
- スクリプトは下記のものをそのまま利用させていただいた 
 - https://repro.esa.io/posts/8390

# why

- ReproのDBは一部の項目がbase64によってエンコードされており、読めないため

# 使用例

```
$ decode64 TG9naW4tU3RhdGU
Login-State
```